### PR TITLE
Migrate to FSNotify and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This simple tool periodically runs provided SQL-queries and alerts DBAs about failed checks via Telegram.
 It's highly configurable and tracks configuration changes.
 
-We believe such an instrument may help those who are administrating one or several databases on a single Linux server to find data malformations early. Hence promptly notify developers about possible bugs and other oddities like inaccurate manual data manipulation. Other use case -- executing periodic actions like vacuuming on database with failure alerts.
+We believe such an instrument may help those who are administrating one or several databases on a single server to find data malformations early. Hence promptly notify developers about possible bugs and other oddities like inaccurate manual data manipulation. Other use case -- executing periodic actions like vacuuming on database with failure alerts.
 
 And we hope it allows more structured monitoring process than arbitrary one built on shell scripts.
 
-All unnecessary restrictions (PostgreSQL, Telegram, Linux with `libc6` >= 2.29) are coming from our limited resources and current conditions. They are not ideological, so we will be glad to accept pull requests broadening domain of the tool.
+All unnecessary restrictions (PostgreSQL, Telegram) are coming from our limited resources and current conditions. They are not ideological, so we will be glad to accept pull requests broadening domain of the tool.
 
 ### Configuration and usage.
 
@@ -36,7 +36,7 @@ Example contents of `conf.dhall`:
 }
 ```
 
-Files of checks and jobs are plain SQL files with optional comments required for setting check behavior. These files may have arbitrary names with .sql extension.
+Files of checks and jobs are plain SQL files with optional comments required for setting check behavior. These files may have arbitrary names and are searched recursively in configuration directory. Hidden files are never tracked.
 
 Proper check file contents may look like that:
 ```
@@ -93,15 +93,13 @@ This stability is achived in a following manner:
 * System tracks changes in check files and automatically reload them.
 * New check files are automatically tracked and run as jobs.
 * On removal of check file tool stops executing related job. Same for database directories - directory deletion causes monitor for this directory to stop.
-* `conf.dhall` changes are tracked. If config is invalid, old jobs are removed, but database monitor is not stopped, after config fix everything will work again.
-* On removal of `.monitor` directory tool dies with error message.
+* `conf.dhall` changes are tracked. If config is invalid, old jobs are removed, but database monitor is not stopped, when config is fixed everything will work again.
 
 #### Other implementation details
 
-* We do not track hidden files (prefixed with dot). Also we do not care about plain files on a level of database directories but traverse directories on level of check files.
 * If assertion cannot be parsed from `conf.dhall` or check file, it is treated as `not null` instead of throwing error.
 * Database queries are based on `hasql` library, which has quite strict control over what query is expected to return. So you may encounter some unfamiliar errors in Telegram. In all cases we know they are reasonable against provided assertions. Also usage of this library as a backend limits us to PostgeSQL databases. It's possible to extend to other backends.
-* File watch is implemented over `inotify`. It's a Linux kernel subsystem, so it's why tool is Linux-specific. It's possible to extend at least to MacOS using `kqueue` backend.
+* File watch was never tested on Mac and Windows.
 * Hopefully you will find our logs detailed but not floody.
 
 ### Telegram caveat.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Options.Applicative (execParser)
 
-import Monitor.Options (options)
+import Monitor.Configuration.Options (options)
 import Monitor.Entry (runApp)
 
 main :: IO ()

--- a/db-monitor.cabal
+++ b/db-monitor.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3e564ce106d1e8b8422079b3d10dbf3246015f55cb56de8bd266b66dbf011997
+-- hash: a9b3d6df856207cb9057ed79a62b1663487f99cdf6240f9fdc80a724dc4be6fa
 
 name:           db-monitor
 version:        0.1.0
@@ -29,12 +29,13 @@ source-repository head
 
 library
   exposed-modules:
-      Monitor.Config
+      Monitor.Configuration.Config
+      Monitor.Configuration.Options
+      Monitor.Configuration.Read
       Monitor.DataModel
       Monitor.DB
       Monitor.Entry
       Monitor.Loader
-      Monitor.Options
       Monitor.Queue
       Monitor.Telegram
   other-modules:
@@ -50,8 +51,8 @@ library
     , dhall >=1.40.2 && <1.42
     , directory >=1.3.3 && <1.4
     , filepath >=1.4.2 && <1.5
+    , fsnotify >=0.3.0 && <0.4
     , hasql >=1.4.4 && <=1.5.0.5
-    , hinotify >=0.4.1 && <0.5
     , lifted-base >=0.2.3 && <0.3
     , monad-control >=1.0.3 && <1.1
     , mtl >=2.2.2 && <2.3
@@ -81,8 +82,8 @@ executable dbmonitor
     , dhall >=1.40.2 && <1.42
     , directory >=1.3.3 && <1.4
     , filepath >=1.4.2 && <1.5
+    , fsnotify >=0.3.0 && <0.4
     , hasql >=1.4.4 && <=1.5.0.5
-    , hinotify >=0.4.1 && <0.5
     , lifted-base >=0.2.3 && <0.3
     , monad-control >=1.0.3 && <1.1
     , mtl >=2.2.2 && <2.3

--- a/db-monitor.cabal
+++ b/db-monitor.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a9b3d6df856207cb9057ed79a62b1663487f99cdf6240f9fdc80a724dc4be6fa
+-- hash: 175e70a8798aaa00b1184b064a5b9e98a12f919aa100896b7a19bb519efef1ba
 
 name:           db-monitor
 version:        0.1.0
@@ -72,7 +72,7 @@ executable dbmonitor
       Paths_db_monitor
   hs-source-dirs:
       app
-  ghc-options: -threaded -eventlog -rtsopts -with-rtsopts=-N -Wall -Werror
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
   build-depends:
       ansi-terminal >=0.11.3 && <0.12
     , async >=2.2.2 && <2.3

--- a/package.yaml
+++ b/package.yaml
@@ -49,7 +49,7 @@ executables:
     source-dirs:         app
     ghc-options:
     - -threaded
-    - -eventlog
+#    - -eventlog
     - -rtsopts
     - -with-rtsopts=-N
     - -Wall

--- a/package.yaml
+++ b/package.yaml
@@ -17,26 +17,26 @@ category: Monitoring, Database
 description: Please see the README on GitHub at <https://github.com/viviag/dbmonitor#readme>
 
 dependencies:
-- ansi-terminal                 >= 0.11.3 && < 0.12
-- base                          >= 4.12.0 && <= 4.15.1.0
-- async                         >= 2.2.2 && < 2.3
-- bytestring                    >= 0.10.8 && < 0.11
-- text                          >= 1.2.3 && < 1.3
-- stm                           >= 2.5.0 && < 2.6
-- dhall                         >= 1.40.2 && < 1.42
-- time                          >= 1.8.0 && <= 1.9.3
-- unordered-containers          >= 0.2.10 && < 0.3
-- vector                        >= 0.12.0 && < 0.13
-- filepath                      >= 1.4.2 && < 1.5
-- directory                     >= 1.3.3 && < 1.4
-- mtl                           >= 2.2.2 && < 2.3
-- optparse-applicative          >= 0.16.1.0 && < 0.18
-- hasql                         >= 1.4.4 && <= 1.5.0.5
-- hinotify                      >= 0.4.1 && < 0.5
-- lifted-base                   >= 0.2.3 && < 0.3
-- monad-control                 >= 1.0.3 && < 1.1
-- transformers-base             >= 0.4.6 && < 0.5
-- telegram-bot-simple           >= 0.4.5 && < 0.6
+- ansi-terminal        >= 0.11.3 && < 0.12
+- base                 >= 4.12.0 && <= 4.15.1.0
+- async                >= 2.2.2 && < 2.3
+- bytestring           >= 0.10.8 && < 0.11
+- text                 >= 1.2.3 && < 1.3
+- stm                  >= 2.5.0 && < 2.6
+- dhall                >= 1.40.2 && < 1.42
+- time                 >= 1.8.0 && <= 1.9.3
+- unordered-containers >= 0.2.10 && < 0.3
+- vector               >= 0.12.0 && < 0.13
+- filepath             >= 1.4.2 && < 1.5
+- directory            >= 1.3.3 && < 1.4
+- mtl                  >= 2.2.2 && < 2.3
+- optparse-applicative >= 0.16.1.0 && < 0.18
+- hasql                >= 1.4.4 && <= 1.5.0.5
+- fsnotify             >= 0.3.0 && < 0.4
+- lifted-base          >= 0.2.3 && < 0.3
+- monad-control        >= 1.0.3 && < 1.1
+- transformers-base    >= 0.4.6 && < 0.5
+- telegram-bot-simple  >= 0.4.5 && < 0.6
 library:
   source-dirs: src
   ghc-options:

--- a/src/Monitor/Configuration/Config.hs
+++ b/src/Monitor/Configuration/Config.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE BangPatterns #-}
-module Monitor.Config where
+module Monitor.Configuration.Config where
 
 import System.Console.ANSI
 import System.IO (hFlush, stdout)

--- a/src/Monitor/Configuration/Options.hs
+++ b/src/Monitor/Configuration/Options.hs
@@ -1,4 +1,4 @@
-module Monitor.Options where
+module Monitor.Configuration.Options where
 
 import Options.Applicative
 

--- a/src/Monitor/Configuration/Read.hs
+++ b/src/Monitor/Configuration/Read.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ImplicitParams #-}
+module Monitor.Configuration.Read
+  ( readMonitor
+  , notHidden
+  , isCheck
+  , collectMonitors
+  )
+  where
+
+import Control.Concurrent
+
+import System.Directory
+import System.FilePath
+import System.FSNotify
+
+import Monitor.Configuration.Config
+import Monitor.DataModel
+
+collectMonitors :: FilePath -> IO [FilePath]
+collectMonitors configDir = do
+  mDatabaseDirs <- listDirectory configDir
+  filterM doesDirectoryExist
+    (map (configDir </>) . filter notHidden $ mDatabaseDirs)
+
+tryReadConfig :: (?mutex :: Mutexes) => FilePath -> MVar () -> String -> IO Settings
+tryReadConfig dir configChange tgvar = do
+  takeMVar configChange
+  readConfig dir configChange tgvar
+
+readConfig :: (?mutex :: Mutexes) => FilePath -> MVar () -> String -> IO Settings
+readConfig dir configChange tgvar = do
+  let configPath = dir </> configName
+  configExists <- doesFileExist configPath
+  if configExists
+    then do
+      mSettings <- readSettings dir tgvar configPath
+      case mSettings of
+        Nothing -> tryReadConfig dir configChange tgvar
+        Just cfg -> return cfg
+    else tryReadConfig dir configChange tgvar
+
+modifiedCfg :: MVar () -> Event -> IO ()
+modifiedCfg mvar _ = putMVar mvar ()
+
+readConfigTillSuccess :: (?mutex :: Mutexes)
+                      => WatchManager -> FilePath -> String -> MVar () -> IO Settings
+readConfigTillSuccess cfgManager dir tgvar configChange = do
+  removeWatch <- watchDir cfgManager dir (const True)
+    (modifiedCfg configChange)
+  cfg <- readConfig dir configChange tgvar
+  logMessage $ "Successfully read configuration at " <> dir
+  removeWatch
+  return cfg
+
+notHidden :: FilePath -> Bool
+notHidden ('.':_) = False
+notHidden _ = True
+
+isCheck :: FilePath -> Bool
+isCheck f = notHidden f && (f /= configName) -- && takeExtension f == ".sql"
+
+readInitialData :: FilePath -> IO [FilePath]
+readInitialData dir = do
+  contents <- listDirectory dir
+  files <- filterM doesFileExist . map (dir </>) . filter isCheck $ contents
+  subdirs <- filterM doesDirectoryExist . map (dir </>) . filter notHidden $ contents
+  case subdirs of
+    [] -> return files
+    lst -> mapM (readInitialData) lst
+       >>= \nested -> return (files ++ concat nested)
+
+readMonitor :: (?mutex :: Mutexes) => FilePath -> String -> IO (Settings, [FilePath])
+readMonitor dir tgvar = do
+  configReadMVar <- newEmptyMVar
+  cfg <- withManager (\cfgManager -> readConfigTillSuccess cfgManager dir tgvar configReadMVar)
+  checks <- readInitialData dir
+  return (cfg, checks)

--- a/src/Monitor/Configuration/Read.hs
+++ b/src/Monitor/Configuration/Read.hs
@@ -20,8 +20,10 @@ import Monitor.DataModel
 collectMonitors :: FilePath -> IO [FilePath]
 collectMonitors configDir = do
   mDatabaseDirs <- listDirectory configDir
-  filterM doesDirectoryExist
+  relativePaths <- filterM doesDirectoryExist
     (map (configDir </>) . filter notHidden $ mDatabaseDirs)
+  currentDir <- getCurrentDirectory
+  return $ map (currentDir </>) relativePaths
 
 tryReadConfig :: (?mutex :: Mutexes) => FilePath -> MVar () -> String -> IO Settings
 tryReadConfig dir configChange tgvar = do

--- a/src/Monitor/DataModel.hs
+++ b/src/Monitor/DataModel.hs
@@ -29,8 +29,8 @@ newtype Monitor a = Monitor {getMonitor :: ReaderT Settings IO a} deriving
 configName :: FilePath
 configName = "conf.dhall"
 
-data JobAction = Start | Restart | Remove
-  deriving (Eq, Show)
+representsConfigName :: FilePath -> Bool
+representsConfigName path = path == configName
 
 data JobFeedback = ConnectionError String
                  | QueryError String

--- a/src/Monitor/DataModel.hs
+++ b/src/Monitor/DataModel.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Monitor.DataModel (
     module Monitor.DataModel
   , module Control.Monad.Reader
@@ -18,15 +20,11 @@ import Control.Monad.Trans.Control
 
 import Data.ByteString (ByteString)
 
-import Monitor.Config
+import Monitor.Configuration.Config
 
 newtype Monitor a = Monitor {getMonitor :: ReaderT Settings IO a} deriving
-  (Functor, Applicative, Monad, MonadIO, MonadReader Settings, MonadBase IO)
-
-instance MonadBaseControl IO Monitor where
-  type StM Monitor a = a
-  liftBaseWith f = Monitor $ liftBaseWith $ \q -> f (q . getMonitor)
-  restoreM = Monitor . restoreM
+  (Functor, Applicative, Monad, MonadIO, MonadReader Settings, MonadBase IO, MonadBaseControl IO)
+  via ReaderT Settings IO
 
 configName :: FilePath
 configName = "conf.dhall"

--- a/src/Monitor/Entry.hs
+++ b/src/Monitor/Entry.hs
@@ -7,29 +7,24 @@ import GHC.Conc (labelThread)
 import Control.Concurrent
 import Control.Concurrent.Async
 
-import System.Directory
 import System.Exit
 import System.FilePath
-import System.INotify
+import System.FSNotify
 
-import qualified Data.ByteString.Char8 as BSC
-
-import Monitor.Options (Options(..))
-import Monitor.Config
+import Monitor.Configuration.Options (Options(..))
+import Monitor.Configuration.Config
+import Monitor.Configuration.Read
 import Monitor.Queue
 import Monitor.DataModel
 
-updateEventVariety :: [EventVariety]
-updateEventVariety = [Modify, Move, MoveIn, MoveOut, Create, Delete, DeleteSelf, MoveSelf]
-
-jobAction :: (?mutex :: Mutexes) => INotify -> FilePath -> String -> JobAction -> Settings -> FilePath -> IO ()
+jobAction :: (?mutex :: Mutexes) => WatchManager -> FilePath -> String -> JobAction -> Settings -> FilePath -> IO ()
 jobAction watcher dir tgvar action cfg path = if notHidden path
   then if path == configName
     then do
+      stopManager watcher
       flip runReaderT cfg . getMonitor $ destroyQueue
       logMessage ("Monitor at " <> dir <> " is stopped due to configuration change. All jobs are removed, monitor will be restarted.")
-      tryToEnter dir tgvar
-      killINotify watcher
+      trackDatabase tgvar dir
     else
       label path . async . flip runReaderT cfg . getMonitor $ case action of
         Start -> startJob (dir </> path)
@@ -37,99 +32,37 @@ jobAction watcher dir tgvar action cfg path = if notHidden path
         Remove -> removeJob (dir </> path)
   else pure ()
 
-watchTower :: (?mutex :: Mutexes) => INotify -> FilePath -> String -> Settings -> Event -> IO ()
-watchTower watcher dir _ cfg DeletedSelf = logMessage ("Monitor at " <> dir <> " is stopped due to directory deletion." )
-                                        >> runReaderT (getMonitor $ destroyMonitor watcher) cfg
-watchTower watcher dir _ cfg (MovedSelf _) = logMessage ("Monitor at " <> dir <> " is stopped due to directory move." )
-                                          >> runReaderT (getMonitor $ destroyMonitor watcher) cfg
-watchTower watcher dir tgvar cfg (Modified False (Just path)) =
-  jobAction watcher dir tgvar Restart cfg (BSC.unpack path)
-watchTower watcher dir tgvar cfg (Deleted False path) =
-  jobAction watcher dir tgvar Remove cfg $ BSC.unpack path
-watchTower watcher dir tgvar cfg (MovedOut False path _) =
-  jobAction watcher dir tgvar Remove cfg $ BSC.unpack path
-watchTower watcher dir tgvar cfg (MovedIn False path _) =
-  jobAction watcher dir tgvar Start cfg (BSC.unpack path)
-watchTower watcher dir tgvar cfg (Created False path) =
-  jobAction watcher dir tgvar Start cfg $ BSC.unpack path
+watchTower :: (?mutex :: Mutexes)
+           => WatchManager -> FilePath -> String -> Settings -> Event -> IO ()
+watchTower watcher dir _ cfg (Removed path _ True)
+    = if path == dir
+      then logMessage ("Monitor at " <> dir <> " is stopped due to directory deletion." )
+        >> runReaderT (getMonitor $ destroyMonitor watcher) cfg
+      else pure ()
+watchTower watcher dir tgvar cfg (Modified path _ False) =
+  jobAction watcher dir tgvar Restart cfg path
+watchTower watcher dir tgvar cfg (Removed path _ False) =
+  jobAction watcher dir tgvar Remove cfg path
+watchTower watcher dir tgvar cfg (Added path _ False) =
+  jobAction watcher dir tgvar Start cfg path
 watchTower _ _ _ _ _ = pure ()
 
-enter :: (?mutex :: Mutexes) => INotify -> FilePath -> [FilePath] -> String -> Settings -> IO ()
-enter watcher dir checks tgvar cfg = do
-  void $ addWatch watcher updateEventVariety (BSC.pack dir) (watchTower watcher dir tgvar cfg)
-  mapM_ (\f -> void . async $ runReaderT (getMonitor $ startJob f) cfg) checks
-
-tryReadConfig :: (?mutex :: Mutexes) => FilePath -> MVar () -> String -> IO Settings
-tryReadConfig dir configChange tgvar = do
-  takeMVar configChange
-  readConfig dir configChange tgvar
-
-readConfig :: (?mutex :: Mutexes) => FilePath -> MVar () -> String -> IO Settings
-readConfig dir configChange tgvar = do
-  let configPath = dir </> configName
-  configExists <- doesFileExist configPath
-  if configExists
-    then do
-      mSettings <- readSettings dir tgvar configPath
-      case mSettings of
-        Nothing -> tryReadConfig dir configChange tgvar
-        Just cfg -> return cfg
-    else tryReadConfig dir configChange tgvar
-
-modifiedCfg :: MVar () -> Event -> IO ()
-modifiedCfg mvar _ = putMVar mvar ()
-
-readConfigTillSuccess :: (?mutex :: Mutexes) => INotify -> FilePath -> String -> MVar () -> IO Settings
-readConfigTillSuccess watcher dir tgvar configChange = do
-  wd <- addWatch watcher updateEventVariety (BSC.pack dir)
-    (modifiedCfg configChange)
-  cfg <- readConfig dir configChange tgvar
-  logMessage $ "Successfully read configuration at " <> dir
-  removeWatch wd
-  return cfg
-
-notHidden :: FilePath -> Bool
-notHidden ('.':_) = False
-notHidden _ = True
-
-isCheck :: FilePath -> Bool
-isCheck f = notHidden f && (f /= configName) -- && takeExtension f == ".sql"
-
-readInitialData :: FilePath -> IO [FilePath]
-readInitialData dir = do
-  contents <- listDirectory dir
-  files <- filterM doesFileExist . map (dir </>) . filter isCheck $ contents
-  subdirs <- filterM doesDirectoryExist . map (dir </>) . filter notHidden $ contents
-  case subdirs of
-    [] -> return files
-    lst -> mapM (readInitialData) lst
-       >>= \nested -> return (files ++ concat nested)
-
-readMonitor :: (?mutex :: Mutexes) => FilePath -> String -> IO (Settings, [FilePath])
-readMonitor dir tgvar = do
-  configReadMVar <- newEmptyMVar
-  cfg <- withINotify (\ino -> readConfigTillSuccess ino dir tgvar configReadMVar)
-  checks <- readInitialData dir
-  return (cfg, checks)
-
-tryToEnter :: (?mutex :: Mutexes) => FilePath -> String -> IO ()
-tryToEnter dir tgvar = do
-  (cfg, checks) <- readMonitor dir tgvar
-  ino <- initINotify
-  enter ino dir checks tgvar cfg
-
 trackDatabase :: (?mutex :: Mutexes) => String -> FilePath -> IO ()
-trackDatabase tgvar dbDir = do
-  logMessage $ "Started tracking directory " <> dbDir <> " in separate thread."
-  tryToEnter dbDir tgvar
+trackDatabase tgvar dbDir = withManager $
+  \monitorManager -> do
+    (cfg, checks) <- readMonitor dbDir tgvar
+    logMessage $ "Monitor at " <> dbDir <> " is started."
+    void $ watchTree monitorManager dbDir (const True) (watchTower monitorManager dbDir tgvar cfg)
+    mapM_ (\f -> void . async $ runReaderT (getMonitor $ startJob f) cfg) checks
 
 -- FIXME: excess thread spawn?
 watchNewTrack :: (?mutex :: Mutexes) => FilePath -> String -> Event -> IO ()
-watchNewTrack _ _ DeletedSelf = die "Configuration directory deleted, exiting."
-watchNewTrack dir tgvar (MovedIn True path _) =
-  trackDatabase tgvar $ dir </> BSC.unpack path
-watchNewTrack dir tgvar (Created True path) =
-  trackDatabase tgvar $ dir </> BSC.unpack path
+watchNewTrack dir _ (Removed path _ True)
+    = if path == dir
+      then die "Configuration directory deleted, exiting."
+      else pure ()
+watchNewTrack dir tgvar (Added path _ True) =
+  spawnMonitorThread tgvar $ dir </> path
 watchNewTrack _ _ _ = pure ()
 
 label :: String -> IO (Async ()) -> IO ()
@@ -137,19 +70,23 @@ label lab action = do
   asyn <- action
   labelThread (asyncThreadId asyn) lab
 
+spawnMonitorThread :: (?mutex :: Mutexes) => String -> FilePath -> IO ()
+spawnMonitorThread tgvar dir =
+  label dir . async $ trackDatabase tgvar dir
+
+trackNewMonitors :: (?mutex :: Mutexes) => Options -> IO ()
+trackNewMonitors Options{..} = do
+  withManager $ \mainWatcher -> do
+    void $ watchTree mainWatcher optionsDir (const True)
+            ( watchNewTrack optionsDir optionsToken
+            )
+
 runApp :: Options -> IO ()
-runApp Options{..} = do
+runApp opts@Options{..} = do
   stdoutMutex <- newMVar ()
   let ?mutex = Mutexes{..} in do
     logMessage "dbmonitor process started."
-    mDatabaseDirs <- listDirectory optionsDir
-    databaseDirs <- filterM doesDirectoryExist (map (optionsDir </>) . filter notHidden $ mDatabaseDirs)
-    mainWatcher <- initINotify
-    void $ addWatch mainWatcher [MoveIn, Create, DeleteSelf] (BSC.pack optionsDir)
-            ( label optionsDir . async . watchNewTrack optionsDir optionsToken
-            )
-    mapM_ (void . async . trackDatabase optionsToken) databaseDirs
-    -- FIXME: should exit properly if somehow fs watcher terminates with daemon running.
+    databaseDirs <- collectMonitors optionsDir
+    trackNewMonitors opts
+    forM_ databaseDirs $ spawnMonitorThread optionsToken
     void . forever $ threadDelay maxBound
-    -- FIXME: signals handling. Take care of non-unix systems.
-    --killINotify mainWatcher

--- a/src/Monitor/Entry.hs
+++ b/src/Monitor/Entry.hs
@@ -17,51 +17,48 @@ import Monitor.Configuration.Read
 import Monitor.Queue
 import Monitor.DataModel
 
-jobAction :: (?mutex :: Mutexes) => WatchManager -> FilePath -> String -> JobAction -> Settings -> FilePath -> IO ()
-jobAction watcher dir tgvar action cfg path = if notHidden path
-  then if path == configName
+watchTower :: (?mutex :: Mutexes)
+           => MVar () -> FilePath -> String -> Settings -> Event -> IO ()
+watchTower monitorHolder dir _ cfg (Removed path _ True) = if path == dir
+  then logMessage ("Monitor at " <> dir <> " is stopped due to directory deletion." )
+    >> runReaderT (getMonitor $ destroyMonitor monitorHolder) cfg
+  else pure ()
+watchTower monitorHolder dir tgvar cfg event = do
+  let path = eventPath event
+      filename = takeFileName path
+  if isCheck filename
     then do
-      stopManager watcher
+      label path . async
+                 . flip runReaderT cfg
+                 . getMonitor $
+        case event of
+          Modified _ _ False -> restartJob path
+          Removed _ _ False -> removeJob path
+          Added _ _ False -> startJob path
+          _ -> pure ()
+    else when (representsConfigName filename) $ do
+      putMVar monitorHolder ()
       flip runReaderT cfg . getMonitor $ destroyQueue
       logMessage ("Monitor at " <> dir <> " is stopped due to configuration change. All jobs are removed, monitor will be restarted.")
       trackDatabase tgvar dir
-    else
-      label path . async . flip runReaderT cfg . getMonitor $ case action of
-        Start -> startJob (dir </> path)
-        Restart -> restartJob (dir </> path)
-        Remove -> removeJob (dir </> path)
-  else pure ()
-
-watchTower :: (?mutex :: Mutexes)
-           => WatchManager -> FilePath -> String -> Settings -> Event -> IO ()
-watchTower watcher dir _ cfg (Removed path _ True)
-    = if path == dir
-      then logMessage ("Monitor at " <> dir <> " is stopped due to directory deletion." )
-        >> runReaderT (getMonitor $ destroyMonitor watcher) cfg
-      else pure ()
-watchTower watcher dir tgvar cfg (Modified path _ False) =
-  jobAction watcher dir tgvar Restart cfg path
-watchTower watcher dir tgvar cfg (Removed path _ False) =
-  jobAction watcher dir tgvar Remove cfg path
-watchTower watcher dir tgvar cfg (Added path _ False) =
-  jobAction watcher dir tgvar Start cfg path
-watchTower _ _ _ _ _ = pure ()
 
 trackDatabase :: (?mutex :: Mutexes) => String -> FilePath -> IO ()
-trackDatabase tgvar dbDir = withManager $
-  \monitorManager -> do
-    (cfg, checks) <- readMonitor dbDir tgvar
-    logMessage $ "Monitor at " <> dbDir <> " is started."
-    void $ watchTree monitorManager dbDir (const True) (watchTower monitorManager dbDir tgvar cfg)
-    mapM_ (\f -> void . async $ runReaderT (getMonitor $ startJob f) cfg) checks
+trackDatabase tgvar dbDir = do
+  (cfg, checks) <- readMonitor dbDir tgvar
+  logMessage $ "Monitor at " <> dbDir <> " is started."
+  withManager $
+    \monitorManager -> do
+      hold <- newEmptyMVar
+      void $ watchTree monitorManager dbDir (const True)
+             (watchTower hold dbDir tgvar cfg)
+      mapM_ (\f -> void . async $ runReaderT (getMonitor $ startJob f) cfg) checks
+      takeMVar hold
 
--- FIXME: excess thread spawn?
 watchNewTrack :: (?mutex :: Mutexes) => FilePath -> String -> Event -> IO ()
-watchNewTrack dir _ (Removed path _ True)
-    = if path == dir
-      then die "Configuration directory deleted, exiting."
-      else pure ()
-watchNewTrack dir tgvar (Added path _ True) =
+watchNewTrack dir _ (Removed path _ True) = when (path == dir) $
+  die "Configuration directory deleted, exiting."
+watchNewTrack dir tgvar event@(Added path _ True) = do
+  print event
   spawnMonitorThread tgvar $ dir </> path
 watchNewTrack _ _ _ = pure ()
 

--- a/src/Monitor/Queue.hs
+++ b/src/Monitor/Queue.hs
@@ -11,7 +11,6 @@ import Control.Concurrent.STM.TVar
 
 import System.Directory
 import System.FilePath
-import System.FSNotify
 
 import qualified Data.HashMap.Strict as HM
 import Data.Maybe
@@ -108,8 +107,8 @@ destroyQueue = do
   mapM_ (liftIO . killThread) $ HM.elems queue
   liftIO . atomically $ modifyTVar queueTVar (\_ -> HM.empty)
 
-destroyMonitor :: (?mutex :: Mutexes) => WatchManager -> Monitor ()
-destroyMonitor watcher = do
+destroyMonitor :: (?mutex :: Mutexes) => MVar () -> Monitor ()
+destroyMonitor monitorHolder = do
+  liftIO $ putMVar monitorHolder ()
   destroyQueue
   alertThreadDeath
-  liftIO $ stopManager watcher

--- a/src/Monitor/Queue.hs
+++ b/src/Monitor/Queue.hs
@@ -11,7 +11,7 @@ import Control.Concurrent.STM.TVar
 
 import System.Directory
 import System.FilePath
-import System.INotify
+import System.FSNotify
 
 import qualified Data.HashMap.Strict as HM
 import Data.Maybe
@@ -108,8 +108,8 @@ destroyQueue = do
   mapM_ (liftIO . killThread) $ HM.elems queue
   liftIO . atomically $ modifyTVar queueTVar (\_ -> HM.empty)
 
-destroyMonitor :: (?mutex :: Mutexes) => INotify -> Monitor ()
+destroyMonitor :: (?mutex :: Mutexes) => WatchManager -> Monitor ()
 destroyMonitor watcher = do
   destroyQueue
   alertThreadDeath
-  liftIO $ killINotify watcher
+  liftIO $ stopManager watcher


### PR DESCRIPTION
Closes #9 

Changes:
- We now rely on event channel as forever active object to protect main thread. Hence we do not need active waiting or strange exports as it was before (See https://github.com/kolmodin/hinotify/issues/34).
- `hinotify` is replaced with `fsnotify`. This results in crossplatformity (as declared, not yet tested), proper recursive directory watching, and significant changes in how we have to work with threads.
- Each monitor is now assigned a mutex which prevents it from early exit. Map of mutexes is stored in transactional memory and is communicated to watcher of new monitors. Then directory is moved or deleted, monitor exit is unlocked. This is the major architecture change and major fix of behaviour of new monitors watcher.
- Configuration reader is moved into separate module.
- All watch managers are now appropriately closed using built-in `bracket` pattern.
- We now have one-to-one correspondence between watches and control threads (monitors, main thread, and configuration reader thread).

From this point I believe it is ready to be on hackage.